### PR TITLE
Update `clear` button text

### DIFF
--- a/templates/logScreenView.html
+++ b/templates/logScreenView.html
@@ -1,6 +1,6 @@
 <div class='controls'>
 <% if (logScreens.length > 1) { %><a href="#" class='close'>close</a><% } %>
-  <a href="#" class='clear'>clear</a>
+  <a href="#" class='clear'>clear screen</a>
   <a href="#" class='filter'>filter <input type='text'/></a>
 </div>
 <div class='messages'>


### PR DESCRIPTION
The text on the clear button, in its context next to the filter input, implies that it's clearing the filter. I've had users who were very surprised when clicking it cleared their log history.

This commit updates the button to read `clear screen` instead, which should help with that confusion.